### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "srecc-vpc" {
 
 module "srecc-ec2-backend" {
   source           = "mujahidhemani/srecc-ec2-autoscale/aws"
-  version          = "1.1.0"
+  version          = "1.1.1"
   vpc_id           = "${module.srecc-vpc.vpc_id}"
   subnet_ids       = "${module.srecc-vpc.all_subnet_ids}"
   target_group_arn = "${module.srecc-frontend.target_group_arn}"
@@ -18,7 +18,7 @@ module "srecc-ec2-backend" {
 
 module "srecc-frontend" {
   source                 = "mujahidhemani/srecc-load-balancer/aws"
-  version                = "1.0.0"
+  version                = "1.0.1"
   vpc_id                 = "${module.srecc-vpc.vpc_id}"
   subnet_ids             = "${module.srecc-vpc.all_subnet_ids}"
   autoscaling_group_name = "${module.srecc-ec2-backend.autoscaling_group_name}"


### PR DESCRIPTION
bump versions of the ec2-autoscale and load-balancer modules 
- to allow multiple instances of outyet to be deployed to the same aws account